### PR TITLE
Declare global CouchDb view methods

### DIFF
--- a/src/couchdb/js-design-document.ts
+++ b/src/couchdb/js-design-document.ts
@@ -1,3 +1,14 @@
+// Functions accessible within CouchDb design documents.
+//
+// The complete list is here:
+// https://docs.couchdb.org/en/stable/query-server/javascript.html
+// Many of these are either deprecated or redundant with built-in JS things,
+// so we keep this list trimmed down to the bare essentials,
+// to avoid polluting the global namespace as much as possible.
+declare global {
+  function emit(key?: unknown, value?: unknown): void
+}
+
 export interface JsView {
   map: string
   reduce?: string


### PR DESCRIPTION
With these declarations in place, CouchDb view code can freely use `emit` and `log` as necessary.