### PR TITLE
William/document watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "cleaners": "^0.3.9",
     "nano": "^9.0.3",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "yavent": "^0.1.3"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "cleaners": "^0.3.9",
-    "nano": "^9.0.3",
+    "nano": "^9.0.4",
     "node-fetch": "^2.6.1",
     "yavent": "^0.1.3"
   },

--- a/src/couchdb/mango-design-document.ts
+++ b/src/couchdb/mango-design-document.ts
@@ -58,10 +58,12 @@ export function makeMangoIndex(
       partial_filter_selector: filter ?? {}
     },
     reduce: '_count',
-    options: { def: { fields } }
-  }
-  if (filter != null) {
-    view.options.def.partial_filter_selector = filter
+    options: {
+      def: {
+        fields,
+        partial_filter_selector: filter
+      }
+    }
   }
 
   // Return the design document:

--- a/src/couchdb/synced-document.ts
+++ b/src/couchdb/synced-document.ts
@@ -1,0 +1,94 @@
+import { asMaybe, asObject, asValue, Cleaner, uncleaner } from 'cleaners'
+import { DocumentScope } from 'nano'
+import { makeEvent, OnEvent } from 'yavent'
+
+import { matchJson } from '../util/match-json'
+import { asCouchDoc } from './as-couch-doc'
+
+/**
+ * Babysits a Couch document, ensuring it exists and is clean.
+ *
+ * The `sync` method fetches, cleans, and updates the document
+ * on the database (which might involve creating the document).
+ * It then updates the babysitter object with the final result
+ * and calls `onChange` if the contents or rev differ.
+ */
+export interface SyncedDocument<T> {
+  doc: T
+  rev?: string
+
+  readonly id: string
+  readonly onChange: OnEvent<T>
+
+  /**
+   * Syncs the document with the database.
+   * Creates or repairs missing or unclean documents,
+   * but throws all other database failures.
+   */
+  readonly sync: (db: DocumentScope<unknown>) => Promise<void>
+}
+
+/**
+ * Babysits a Couch document, ensuring it exists and is clean.
+ *
+ * The cleaner should be able to turn the empty object (`{}`)
+ * into a valid fallback value, such as by using `asMaybe`.
+ * The fallback will be the initial value of the returned babysitter,
+ * until `sync` is called to sync with the database.
+ */
+export function syncedDocument<T>(
+  id: string,
+  cleaner: Cleaner<T>
+): SyncedDocument<T> {
+  const fallback = cleaner({})
+  const asDocument = asCouchDoc(asMaybe(cleaner, fallback))
+  const wasDocument = uncleaner(asDocument)
+  const [on, emit] = makeEvent<T>()
+
+  const out: SyncedDocument<T> = {
+    doc: fallback,
+    rev: undefined,
+    id,
+    onChange: on,
+
+    sync: withMutex(async (db: DocumentScope<unknown>): Promise<void> => {
+      const raw = await db.get(id).catch(async error => {
+        if (asMaybeNotFound(error) == null) throw error
+        return { _id: id }
+      })
+      const clean = asDocument(raw)
+      const dirty = wasDocument(clean)
+      if (!matchJson(dirty, raw)) {
+        const result = await db.insert(dirty as any)
+        out.rev = result.rev
+        out.doc = clean.doc
+        emit(clean.doc)
+      } else if (out.rev !== clean.rev) {
+        out.rev = clean.rev
+        out.doc = clean.doc
+        emit(clean.doc)
+      }
+    })
+  }
+  return out
+}
+
+/**
+ * Causes the passed function to never run in parallel.
+ */
+function withMutex<A extends unknown[], R>(
+  f: (...args: A) => Promise<R>
+): (...args: A) => Promise<R> {
+  let running: Promise<R> | undefined
+  return async (...args: A): Promise<R> => {
+    if (running == null) running = f(...args)
+    else running = running.then(async () => await f(...args))
+    return await running
+  }
+}
+
+const asMaybeNotFound = asMaybe(
+  asObject({
+    error: asValue('not_found')
+  })
+)

--- a/src/couchdb/watch-database.ts
+++ b/src/couchdb/watch-database.ts
@@ -1,0 +1,43 @@
+import { DocumentScope } from 'nano'
+
+import { SyncedDocument } from './synced-document'
+
+export interface CouchChange {
+  seq?: string
+  id: string
+  changes: Array<{ rev: string }>
+  doc?: unknown
+}
+
+/**
+ * Subscribes to a database change feed,
+ * and uses that to trigger updates on an array of document watchers.
+ */
+export async function watchDatabase(
+  db: DocumentScope<unknown>,
+  opts: {
+    onChange?: (change: CouchChange) => void
+    onError?: (error: unknown) => void
+    syncedDocuments?: Array<SyncedDocument<unknown>>
+  } = {}
+): Promise<void> {
+  const { onChange = () => {}, onError = () => {}, syncedDocuments = [] } = opts
+
+  // Watch the database for changes:
+  db.changesReader
+    .start({ since: 'now' })
+    .on('change', (change: CouchChange): void => {
+      for (const doc of syncedDocuments) {
+        if (doc.id === change.id) {
+          doc.sync(db).catch(onError)
+        }
+      }
+      onChange(change)
+    })
+    .on('error', onError)
+
+  // Do an initial sync:
+  for (const doc of syncedDocuments) {
+    await doc.sync(db).catch(onError)
+  }
+}

--- a/src/util/match-json.ts
+++ b/src/util/match-json.ts
@@ -26,9 +26,14 @@ export function matchJson(a: any, b: any): boolean {
     return true
   }
 
-  // These are both regular objects, so grab the keys:
-  const aKeys = Object.getOwnPropertyNames(a)
-  const bKeys = Object.getOwnPropertyNames(b)
+  // These are both regular objects, so grab the keys,
+  // ignoring entries where the value is `undefined`:
+  const aKeys = Object.getOwnPropertyNames(a).filter(
+    key => a[key] !== undefined
+  )
+  const bKeys = Object.getOwnPropertyNames(b).filter(
+    key => b[key] !== undefined
+  )
   if (aKeys.length !== bKeys.length) return false
 
   // We know that both objects have the same number of properties,

--- a/test/mango-design-document.test.ts
+++ b/test/mango-design-document.test.ts
@@ -33,7 +33,8 @@ const testCases: TestCase[] = [
           reduce: '_count',
           options: {
             def: {
-              fields: ['up', 'away']
+              fields: ['up', 'away'],
+              partial_filter_selector: undefined
             }
           }
         }

--- a/test/match-json.test.ts
+++ b/test/match-json.test.ts
@@ -27,4 +27,10 @@ describe('matchJson', function () {
     expect(matchJson({ a: 1, b: 2 }, { a: 1, b: 3 })).equals(false)
     expect(matchJson({ a: 1, b: 2 }, null)).equals(false)
   })
+
+  it('treats undefined and missing equally', function () {
+    expect(matchJson({ a: 1 }, { a: 1, c: undefined })).equals(true)
+    expect(matchJson({ a: 1, b: undefined }, { a: 1 })).equals(true)
+    expect(matchJson({ a: 1, c: 1 }, { a: 1, c: undefined })).equals(false)
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2641,6 +2641,11 @@ yargs@16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yavent@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/yavent/-/yavent-0.1.3.tgz#c86a5e1d013721eda9c732e820fb7d6aaf2ab4db"
+  integrity sha512-O6ZngnMCkiM1Bg/zP2XKgprjXUuHS0tSQjHxWhMc53avgNu6AT5zcmDm+oYxQLRXQ9ajlEQwQ+Rf7CghKt1u1A==
+
 yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,10 +1688,10 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nano@^9.0.3:
-  version "9.0.3"
-  resolved "https://registry.yarnpkg.com/nano/-/nano-9.0.3.tgz#5f7e75962fbebf27f7791fb520a4f45c2bb425d2"
-  integrity sha512-NFI8+6q5ihnozH6qK+BJ+ilnPfZzBhlUswaFgqUvSp2EN5eJ2BMxbzkYiBsN+waa+N95FculCdbneDmzLWfXaQ==
+nano@^9.0.4:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/nano/-/nano-9.0.4.tgz#4c316d08b6501e940186c68b3d6731b2837f6157"
+  integrity sha512-hDf8r9iMiIgyXcIO/hWoTdawCTTFdjmcmGyAN+KaW86O8hVdZxr+Zid5vh51DYpsR8pE4AAu90Ts57Tjpwlqwg==
   dependencies:
     "@types/tough-cookie" "^4.0.0"
     axios "^0.21.1"


### PR DESCRIPTION
This adds `syncedDocument` and `watchDatabase` functions to the server tools.

The `syncedDocument` function manages a single document, ensuring that it exists and stays clean when requested (but it does not watch for changes).

The `watchDatabase` function subscribes to the Couch change feed and passes events along to an array of `syncedDocument` instances, keeping them up-to-date automatically in response to changes.