### PR TITLE
Allow replication setup to include filters

### DIFF
--- a/src/couchdb/replicator-setup-document.ts
+++ b/src/couchdb/replicator-setup-document.ts
@@ -1,4 +1,12 @@
-import { asMaybe, asObject, asString, asValue, Cleaner } from 'cleaners'
+import {
+  asArray,
+  asMaybe,
+  asObject,
+  asOptional,
+  asString,
+  asValue,
+  Cleaner
+} from 'cleaners'
 
 import { asHealingObject } from '../cleaners/as-healing-object'
 
@@ -15,6 +23,12 @@ export interface ReplicatorSetupDocument {
       // The base64 "username:password" pair used to authenticate.
       // To get this, run `btoa('username:password')` in a JS console:
       basicAuth?: string
+
+      // Database names to replicate with this cluster.
+      // Leave the list missing to skip filtering, and use an ending '*'
+      // to treat an entry as a prefix instead of an exact name.
+      exclude?: string[]
+      include?: string[]
 
       // How the replications should take place.
       // If a replicator is a "source", its peers will pull changes from it.
@@ -34,6 +48,8 @@ export const asReplicatorSetupDocument: Cleaner<ReplicatorSetupDocument> =
       asObject({
         url: asMaybe(asString, ''),
         basicAuth: asMaybe(asString),
+        exclude: asMaybe(asOptional(asArray(asString))),
+        include: asMaybe(asOptional(asArray(asString))),
         mode: asMaybe(asValue('source', 'target', 'both'), 'source')
       })
     )

--- a/src/couchdb/setup-database.ts
+++ b/src/couchdb/setup-database.ts
@@ -137,7 +137,10 @@ export async function setupDatabase(
       const documents: { [name: string]: ReplicatorDocument } = {}
       for (const remoteCluster of Object.keys(clusters)) {
         if (remoteCluster === currentCluster) continue
-        const { mode } = clusters[remoteCluster]
+        const { exclude, include, mode } = clusters[remoteCluster]
+
+        if (exclude != null && includesName(exclude, name)) continue
+        if (include != null && !includesName(include, name)) continue
 
         if (mode === 'source' || mode === 'both') {
           documents[`${name}.from.${remoteCluster}`] = {
@@ -178,3 +181,15 @@ const asMaybeNotFound = asMaybe(
     error: asValue('not_found')
   })
 )
+
+/**
+ * Returns true if a list includes a name.
+ * If a list row ends with '*', treat that like a wildcard.
+ */
+function includesName(list: string[], name: string): boolean {
+  const found = list.find(
+    row =>
+      row === (/\*$/.test(row) ? name.slice(0, row.length - 1) + '*' : name)
+  )
+  return found != null
+}


### PR DESCRIPTION
This way, we can replicate some databases to some clusters but not others.