### PR TITLE
Fix rolling databases

### DIFF
--- a/src/couchdb/rolling-database.ts
+++ b/src/couchdb/rolling-database.ts
@@ -149,7 +149,7 @@ export interface RollingDatabase<T> {
  * before the query routines try to access it and fail.
  */
 type RollingDatabaseList = Array<{
-  // True to ignore this database:
+  // True to tag this database as '#archived':
   archived: boolean
 
   // The database name:
@@ -482,6 +482,7 @@ export function makeRollingDatabase<T>(
     // Ensure we have a list database:
     const listDbSetup: DatabaseSetup = {
       name: `${name}-list`,
+      tags,
       onChange() {
         readDbList().catch(onError)
       }

--- a/src/couchdb/setup-database.ts
+++ b/src/couchdb/setup-database.ts
@@ -43,7 +43,8 @@ export interface DatabaseSetup
 export interface SetupDatabaseOptions {
   // The couch cluster name the current client is connected to,
   // as described in the replicator setup document.
-  // This controls which databases and replications we create:
+  // This controls which databases and replications we create.
+  // Falls back to "default" if missing:
   currentCluster?: string
 
   // Describes which database and replications should exist on each cluster:

--- a/src/couchdb/setup-database.ts
+++ b/src/couchdb/setup-database.ts
@@ -122,13 +122,15 @@ async function doSetup(
   opts: SetupDatabaseOptions
 ): Promise<DocumentScope<unknown> | undefined> {
   const { documents = {}, name, options, templates = {} } = setupInfo
-  const { currentCluster = 'default', log = console.log } = opts
-  const replicatorSetup = opts.replicatorSetup?.doc ??
-    setupInfo.replicatorSetup?.doc ?? { clusters: {} }
+  const {
+    currentCluster,
+    log = console.log,
+    replicatorSetup = setupInfo.replicatorSetup
+  } = opts
 
   // Bail out if the current cluster doesn't have this database:
   const { exists, replicated } = clusterHasDatabase(
-    replicatorSetup,
+    replicatorSetup?.doc,
     currentCluster,
     setupInfo
   )
@@ -183,7 +185,7 @@ async function doSetup(
       {
         name: '_replicator',
         documents: makeReplicatorDocuments(
-          replicatorSetup,
+          replicatorSetup?.doc,
           currentCluster,
           currentUsername,
           setupInfo


### PR DESCRIPTION
With the new tagging and filtering system for database setup, we no longer need to use the `useArchived` flag to control which databases we can access or not - the replicator setup contains all the information we need.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203152447363432